### PR TITLE
Update run.sh

### DIFF
--- a/autossh/run.sh
+++ b/autossh/run.sh
@@ -43,10 +43,10 @@ if [ ! -z "$LOCAL_FORWARDING" ]; then
 fi
 
 echo "[INFO] testing ssh connection"
-ssh -o StrictHostKeyChecking=no $HOSTNAME 2>/dev/null || true
+ssh -o StrictHostKeyChecking=no -p $SSH_PORT $HOSTNAME 2>/dev/null || true
 
 echo "[INFO] listing host keys"
-ssh-keyscan $HOSTNAME || true
+ssh-keyscan -p $SSH_PORT $HOSTNAME || true
 
 command_args="${command_args} ${OTHER_SSH_OPTIONS}"
 


### PR DESCRIPTION
Added missing ssh port flags for testing ssh connection and performing the ssh-keyscan actions. with out this we are unable to use a port other than 22.